### PR TITLE
Fix package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "codecov-opentelem-node",
   "version": "0.1.0",
   "description": "",
-  "main": "app.js",
+  "main": "lib/runtime-insights.js",
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
The current entry point is set to a non-existent file:

https://github.com/codecov/opentelem-node/blob/8677339bb8a9a08f3d41ea406988ba1fe9b0344f/package.json#L5