### PR TITLE
Specify `main` for `push` events

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,7 +2,11 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 
 name: Node.js CI
-on: [push, pull_request]
+
+on:
+   push:
+     branches: [ main ]
+   pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This PR re-adds the changes made in #6.

The aforementioned PR was inadvertently reverted in effect because `main` did not require its commits to have a linear history. The requirement has since been added to the branch as a branch protection rule.