### PR TITLE
Create runtime-insights.test.js

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,5 +31,5 @@ jobs:
     - uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage/coverage-final.json
+        files: ./coverage/clover.xml
         flags: unittests

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,5 +31,5 @@ jobs:
     - uses: codecov/codecov-action@v2
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        files: ./coverage/clover.xml
+        files: ./coverage/coverage-final.json
         flags: unittests

--- a/test/runtime-insights.test.js
+++ b/test/runtime-insights.test.js
@@ -1,0 +1,1 @@
+const rti = require("../lib/runtime-insights.js");

--- a/test/runtime-insights.test.js
+++ b/test/runtime-insights.test.js
@@ -1,1 +1,3 @@
 const rti = require("../lib/runtime-insights.js");
+
+test.todo("Do nothing");


### PR DESCRIPTION
runtime-insights.js has no reported coverage data.

This PR adds a test file for the aforementioned source file to help the project's test suite more accurately determine coverage data. Currently, coverage data is only reported for utils.js since it has a corresponding test file.